### PR TITLE
using `tabSize` and `insertSpaces` from `[markdown]` configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,15 +54,19 @@
         "menus": {
             "editor/context": [
                 {
+                    "when": "editorLangId == 'markdown'",
                     "command": "extension.updateMarkdownToc"
                 },
                 {
+                    "when": "editorLangId == 'markdown'",
                     "command": "extension.deleteMarkdownToc"
                 },
                 {
+                    "when": "editorLangId == 'markdown'",
                     "command": "extension.updateMarkdownSections"
                 },
                 {
+                    "when": "editorLangId == 'markdown'",
                     "command": "extension.deleteMarkdownSections"
                 }
             ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -263,8 +263,14 @@ class MarkdownTocTools {
 
     private createToc(editBuilder : TextEditorEdit, headerList : any[], insertPosition : Position) {
         let lineEnding      = <string>  workspace.getConfiguration("files").get("eol");
-        let tabSize         = <number>  workspace.getConfiguration("editor").get("tabSize");
-        let insertSpaces    = <boolean> workspace.getConfiguration("editor").get("insertSpaces");
+        let tabSize         = <number>  workspace.getConfiguration("[markdown]")["editor.tabSize"];
+        if(tabSize === undefined || tabSize === null)
+            tabSize = <number> workspace.getConfiguration("editor").get("tabSize");
+
+        let insertSpaces    = <boolean> workspace.getConfiguration("[markdown]")["editor.insertSpaces"];
+        if(insertSpaces === undefined || insertSpaces === null)
+            insertSpaces = <boolean> workspace.getConfiguration("editor").get("insertSpaces");
+            
         let tab = '\t';
         if (insertSpaces && tabSize > 0) {
             tab = " ".repeat(tabSize);


### PR DESCRIPTION
Instead of directly read `tabSize` and `insertSpaces` global configurations, it is better to check wether user create `[markdown]` specific configuration. This way user can use custom `tabSize` and `insertSpaces` configuration for markdown file only in their project.