### PR TITLE
Regex matches only comments that start with TOC

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,8 +15,8 @@ import {
     TextEditorEdit
 } from 'vscode';
 
-const REGEXP_TOC_START          = /\s*<!--(.*)TOC(.*)-->/gi;
-const REGEXP_TOC_STOP           = /\s*<!--(.*)\/TOC(.*)-->/gi;
+const REGEXP_TOC_START          = /\s*<!--\s*TOC(\s(\.*))?-->/gi;
+const REGEXP_TOC_STOP           = /\s*<!--\s\/TOC(\s(\.*))?-->/gi;
 const REGEXP_TOC_CONFIG         = /\w+[:=][\w.]+/gi;
 const REGEXP_TOC_CONFIG_ITEM    = /(\w+)[:=]([\w.]+)/;
 const REGEXP_MARKDOWN_ANCHOR    = /^<a id="markdown-.+" name=".+"><\/a\>/;


### PR DESCRIPTION
Fixes #50.

See these for regex visualization:

* [`\s*<!--\s*TOC(\s(\.*))?-->`](https://regexper.com/#%5Cs*%3C!--%5Cs*TOC%28%5Cs%28%5C.*%29%29%3F--%3E)
* [`\s*<!--\s\/TOC(\s(\.*))?-->`](https://regexper.com/#%5Cs*%3C!--%5Cs%5C%2FTOC%28%5Cs%28%5C.*%29%29%3F--%3E)