### PR TITLE
Fixed broken line endings when set to auto

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -267,7 +267,11 @@ class MarkdownTocTools {
         let lineEnding      = <string>  workspace.getConfiguration("files").get("eol");
         let tabSize         = <number>  workspace.getConfiguration("[markdown]")["editor.tabSize"];
         let insertSpaces    = <boolean> workspace.getConfiguration("[markdown]")["editor.insertSpaces"];
-            
+        
+        if (lineEnding === "auto") {
+            lineEnding = '\n';
+        }
+
         if(tabSize === undefined || tabSize === null) {
             tabSize = <number> workspace.getConfiguration("editor").get("tabSize");
         }


### PR DESCRIPTION
Should fix issues #65 and #68 

The latest update to VS Code made the default option for line endings be set to "auto", breaking this extension (and many others) by making it insert the word auto rather than newlines.